### PR TITLE
Add corner‑case tests for core overlay

### DIFF
--- a/iOverlay/src/core/overlay.rs
+++ b/iOverlay/src/core/overlay.rs
@@ -429,13 +429,14 @@ mod tests {
 
     #[test]
     fn test_0() {
-        let subj = [[
-            IntPoint::new(0, 0),
-            IntPoint::new(10, 0),
-            IntPoint::new(10, 10),
-            IntPoint::new(0, 10),
-        ]
-            .to_vec()];
+        let subj = [
+            vec![
+                IntPoint::new(0, 0),
+                IntPoint::new(10, 0),
+                IntPoint::new(10, 10),
+                IntPoint::new(0, 10),
+            ],
+        ];
 
         let mut overlay = Overlay::with_contours(&subj, &[]);
         let result = overlay.overlay(OverlayRule::Subject, FillRule::EvenOdd);


### PR DESCRIPTION
## Summary
#30

## Changes
1. Added tests for shared vertices, overlapping edges, and empty input
2. Cleaned the tests from unnecessary ```extern```
3. Brought the definition of the ```subj``` in ```test_0``` into one format

## Testing
- [x] `cargo test`
- [ ] `cargo fmt`
- [x] `cargo clippy`

## Checklist
- [x] Added tests for new behavior or bug fixes
- [ ] Updated docs/examples if needed
