### PR TITLE
buffer segment zero length fix

### DIFF
--- a/iOverlay/src/mesh/outline/offset.rs
+++ b/iOverlay/src/mesh/outline/offset.rs
@@ -444,4 +444,44 @@ mod tests {
         assert!(path.outline_fixed_scale(&style, f64::NAN).is_err());
         assert!(path.outline_fixed_scale(&style, f64::INFINITY).is_err());
     }
+
+    #[test]
+    fn test_zero_length_segment_0() {
+        let path = [
+            [2681.39599938213, 5892784.488998892],
+            [5419.06964821636, 5891947.742386343],
+            [5419.1446127397, 5891949.316633703],
+            [5422.8669123155, 5892027.484991552],
+            [5034.8682417375, 5892817.151239874],
+            [4804.8188261491, 5892876.799252035],
+            [4804.81882805645, 5892876.799253942],
+            [4551.3436274034, 5892942.5211854],
+            [2681.39599938213, 5892784.488998892],
+        ];
+
+        let angle = 10.0f64 / (core::f64::consts::PI / 2.0f64);
+        let style = OutlineStyle::new(150.0).line_join(LineJoin::Round(angle));
+
+        if let Some(shape) = path.outline(&style).first() {
+            assert!(shape[0].len() < 1_000);
+        };
+    }
+
+    #[test]
+    fn test_zero_length_segment_1() {
+        let path = [
+            [2681.39599938213, 5892876.0],
+            [5400.0, 5891947.742386343],
+            [5400.0, 5892817.151239874],
+            [4804.8188261491, 5892876.799252035],
+            [4804.81882805645, 5892876.799253942]
+        ];
+
+        let angle = 10.0f64 / (core::f64::consts::PI / 2.0f64);
+        let style = OutlineStyle::new(150.0).line_join(LineJoin::Round(angle));
+
+        if let Some(shape) = path.outline(&style).first() {
+            assert!(shape[0].len() < 1_000);
+        };
+    }
 }

--- a/iOverlay/src/mesh/outline/section.rs
+++ b/iOverlay/src/mesh/outline/section.rs
@@ -43,6 +43,8 @@ impl<T: FloatNumber, P: FloatPointCompatible<T>> SectionToSegment<T, P> for Vec<
     fn add_section(&mut self, section: &Section<P, T>, adapter: &FloatPointAdapter<P, T>) {
         let a_top = adapter.float_to_int(&section.a_top);
         let b_top = adapter.float_to_int(&section.b_top);
-        self.push(Segment::bold_subject_ab(a_top, b_top));
+        if a_top != b_top {
+            self.push(Segment::bold_subject_ab(a_top, b_top));
+        }
     }
 }

--- a/iOverlay/src/mesh/stroke/section.rs
+++ b/iOverlay/src/mesh/stroke/section.rs
@@ -55,7 +55,11 @@ impl<T: FloatNumber, P: FloatPointCompatible<T>> SectionToSegment<T, P> for Vec<
         let a_bot = adapter.float_to_int(&section.a_bot);
         let b_bot = adapter.float_to_int(&section.b_bot);
 
-        self.push(Segment::bold_subject_ab(b_top, a_top));
-        self.push(Segment::bold_subject_ab(a_bot, b_bot));
+        if a_top != b_top {
+            self.push(Segment::bold_subject_ab(b_top, a_top));
+        }
+        if a_bot != b_bot {
+            self.push(Segment::bold_subject_ab(a_bot, b_bot));
+        }
     }
 }


### PR DESCRIPTION
## Summary
Due to floating-point to integer conversion, the buffer builder can sometimes generate zero-length segments.

## Changes
Added validation to skip zero-length segments during buffer construction.

## Testing
- [x] `cargo test`
- [  ] `cargo fmt`
- [x] `cargo clippy`

## Checklist
- [x] Added tests for new behavior or bug fixes
- [ ] Updated docs/examples if needed
