### PR TITLE
Add tests for string clip edge cases

### DIFF
--- a/iOverlay/src/string/clip.rs
+++ b/iOverlay/src/string/clip.rs
@@ -405,7 +405,7 @@ mod tests {
 
     #[test]
     fn test_shared_vertices_1() {
-        let rect = vec![
+        let contour = vec![
             IntPoint::new(-2, -2),
             IntPoint::new(2, -2),
             IntPoint::new(3, 0),
@@ -419,11 +419,11 @@ mod tests {
             IntPoint::new(4, 1),
         ];
 
-        let result_0 = rect.clip_path(&path, FillRule::NonZero,
+        let result_0 = contour.clip_path(&path, FillRule::NonZero,
             ClipRule { invert: false, boundary_included: false },
         );
 
-        let result_1 = rect.clip_path(&path, FillRule::NonZero,
+        let result_1 = contour.clip_path(&path, FillRule::NonZero,
             ClipRule { invert: false, boundary_included: true },
         );
 


### PR DESCRIPTION
## Summary
#33

## Changes
Added corner-case tests for string clip

## Testing
- [x] `cargo test`
- [ ] `cargo fmt`
- [x] `cargo clippy`

## Checklist
- [x] Added tests for new behavior or bug fixes
- [ ] Updated docs/examples if needed
