### PR TITLE
fix(bind): don't panic on an orphan hole with no containing shell

### DIFF
--- a/iOverlay/src/bind/segment.rs
+++ b/iOverlay/src/bind/segment.rs
@@ -14,6 +14,11 @@ impl ContourIndex {
     pub(crate) const EMPTY: ContourIndex = ContourIndex { data: usize::MAX };
 
     #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.data == usize::MAX
+    }
+
+    #[inline]
     pub(crate) fn is_hole(&self) -> bool {
         self.data & 1 == 1
     }

--- a/iOverlay/src/bind/solver.rs
+++ b/iOverlay/src/bind/solver.rs
@@ -297,7 +297,8 @@ impl<I: IntNumber + SortKey> SortByAngle for [IdSegment<I>] {
 
 #[cfg(test)]
 mod tests {
-    use crate::bind::solver::JoinHoles;
+    use crate::bind::segment::{ContourIndex, IdSegment};
+    use crate::bind::solver::{JoinHoles, ShapeBinder};
     use crate::geom::v_segment::VSegment;
     use alloc::vec;
     use core::cmp::Ordering;
@@ -358,5 +359,35 @@ mod tests {
 
         assert_eq!(short_result, long_result);
         assert_eq!(Ordering::Less, long_result);
+    }
+
+    #[test]
+    fn orphan_hole_without_parent_shell_is_dropped_not_panicking() {
+        // Regression: a hole whose left-bottom anchor has no shell segment
+        // strictly to its left makes `first_less` return `ContourIndex::EMPTY`.
+        // Before the fix, binding indexed `parent_for_child[EMPTY.index()]`
+        // (== usize::MAX >> 1) and panicked with "index out of bounds".
+        let anchor = IdSegment::with_segment(
+            ContourIndex::new_hole(0),
+            VSegment {
+                a: IntPoint::new(0, 5),
+                b: IntPoint::new(1, 6),
+            },
+        );
+        // The only shell edge lies entirely to the right of the hole, so the
+        // sweep never inserts it before the anchor: the hole has no parent shell.
+        let shell_edge = IdSegment::with_segment(
+            ContourIndex::new_shape(0),
+            VSegment {
+                a: IntPoint::new(10, 0),
+                b: IntPoint::new(20, 0),
+            },
+        );
+
+        let solution = ShapeBinder::bind::<i32>(2, vec![anchor], vec![shell_edge]);
+
+        // The orphan hole is marked (usize::MAX) and skipped by the join loop,
+        // instead of crashing.
+        assert_eq!(solution.parent_for_child[0], usize::MAX);
     }
 }

--- a/iOverlay/src/bind/solver.rs
+++ b/iOverlay/src/bind/solver.rs
@@ -94,6 +94,20 @@ impl ShapeBinder {
             }
 
             let target_id = scan_list.first_less(anchor.v_segment.a.x, ContourIndex::EMPTY, anchor.v_segment);
+            let child_index = anchor.contour_index.index();
+
+            if target_id.is_empty() {
+                // No containing contour found to the left of this hole's anchor.
+                // This happens for a degenerate hole whose leftmost edge is
+                // coincident with a shell edge (the strict `first_less` cannot
+                // see an equal-x segment), so it has no real parent shell. Mark
+                // it orphaned and skip it during binding instead of indexing
+                // `parent_for_child`/`children_count_for_parent` with the EMPTY
+                // sentinel (`usize::MAX`), which panicked.
+                parent_for_child[child_index] = usize::MAX;
+                continue;
+            }
+
             let parent_index = if target_id.is_hole() {
                 // index is a hole index
                 // at this moment this hole parent is known
@@ -102,10 +116,10 @@ impl ShapeBinder {
                 target_id.index()
             };
 
-            let child_index = anchor.contour_index.index();
-
             parent_for_child[child_index] = parent_index;
-            children_count_for_parent[parent_index] += 1;
+            if parent_index != usize::MAX {
+                children_count_for_parent[parent_index] += 1;
+            }
         }
 
         BindSolution {
@@ -191,6 +205,11 @@ impl<I: IntNumber + Expiration + SortKey> JoinHoles<I> for Vec<IntShape<I>> {
 
         for (hole_index, hole) in holes.into_iter().enumerate() {
             let shape_index = solution.parent_for_child[hole_index];
+            if shape_index == usize::MAX {
+                // Orphan hole with no containing shell (see ShapeBinder::bind);
+                // dropping it keeps a degenerate sliver from corrupting output.
+                continue;
+            }
             self[shape_index].push(hole);
         }
     }


### PR DESCRIPTION
### Problem

`ShapeBinder::private_solve` (`src/bind/solver.rs`) resolves each hole's parent contour with:

```rust
let target_id = scan_list.first_less(anchor.v_segment.a.x, ContourIndex::EMPTY, anchor.v_segment);
```

When a hole's left-bottom anchor has **no shell segment strictly to its left**, `first_less` returns the `ContourIndex::EMPTY` sentinel (`data: usize::MAX`). The code then unconditionally does:

```rust
let parent_index = if target_id.is_hole() { parent_for_child[target_id.index()] } else { target_id.index() };
...
children_count_for_parent[parent_index] += 1;
```

Because `EMPTY.is_hole()` is `usize::MAX & 1 == 1` (true) and `EMPTY.index()` is `usize::MAX >> 1`, this indexes `parent_for_child[9223372036854775807]` and panics:

```
index out of bounds: the len is N but the index is 9223372036854775807
```

This happens for a **degenerate hole whose leftmost edge is coincident with a shell edge** — the strict `first_less` cannot see the equal-x segment, so the hole appears to have no containing shell. It is reliably triggered by `f64` boolean ops over geometry with many near-coincident edges at high coordinate magnitudes (here: a screen-space visibility resolver subtracting many occluder polygons whose borders coincide with the subject's borders).

### Fix

Detect the `EMPTY` sentinel and treat the hole as **orphaned**: mark it (`usize::MAX`) and skip it during binding and in the join push loop, instead of indexing `parent_for_child` / `children_count_for_parent` with the sentinel. An orphan hole has no valid parent shell, so it is dropped from the output (it is a degenerate sub-pixel artifact in practice).

Adds `ContourIndex::is_empty()` and guards both the producer (`private_solve`) and the consumer (`scan_join`'s push loop).

### Test

Adds `bind::solver::tests::orphan_hole_without_parent_shell_is_dropped_not_panicking`: it feeds `ShapeBinder::bind` a hole anchor with the only shell segment entirely to its right (so the sweep finds no parent). With the guard disabled it reproduces the exact panic (`index out of bounds: the len is 1 but the index is 9223372036854775807`); with the fix it asserts the orphan hole is marked `usize::MAX` (dropped). Full suite: 348 passed.

### Notes
- The same code path exists unchanged in 6.0.1 and 7.0.0.
- Open question: an orphan hole has no valid containing shell, so this PR **drops** it. If you'd rather **attach** it to the outer/nearest shell, I'm happy to adjust.
