### PR TITLE
fix(core): skip non-hole remnants in OGC extraction

### DIFF
--- a/iOverlay/src/core/extract_ogc.rs
+++ b/iOverlay/src/core/extract_ogc.rs
@@ -124,9 +124,22 @@ where
                     self.links.get_unchecked(left_top_link)
                 };
 
-                debug_assert!(overlay_rule.is_fill_top(link.fill));
-
                 let start_data = StartPathData::new(is_main_dir_cw, link, left_top_link);
+                if !overlay_rule.is_fill_top(link.fill) {
+                    // The first pass skips hole contours in the opposite traversal direction.
+                    // A self-touching hole can therefore leave non-hole remnants marked for
+                    // the second pass after the actual hole contour is extracted.
+                    self.find_contour(
+                        &start_data,
+                        is_main_dir_cw,
+                        VisitState::HullVisited,
+                        &mut buffer.visited,
+                        &mut buffer.points,
+                    );
+                    link_index += 1;
+                    continue;
+                }
+                debug_assert!(overlay_rule.is_fill_top(link.fill));
 
                 self.find_contour(
                     &start_data,

--- a/iOverlay/tests/crash_tests.rs
+++ b/iOverlay/tests/crash_tests.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+    use i_float::adapter::FloatPointAdapter;
     use i_float::int::number::int::IntNumber;
     use i_float::int::point::IntPoint;
     use i_key_sort::sort::key::SortKey;
@@ -7,7 +8,7 @@ mod tests {
     use i_overlay::core::overlay::{Overlay, ShapeType};
     use i_overlay::core::overlay_rule::OverlayRule;
     use i_overlay::core::solver::{Precision, Solver, Strategy};
-    use i_overlay::float::overlay::FloatOverlay;
+    use i_overlay::float::overlay::{FloatOverlay, OverlayOptions};
     use i_shape::base::data::{Path, Shape};
     use i_shape::{int_path, int_shape};
     use i_tree::{Expiration, LayoutNumber};
@@ -139,5 +140,43 @@ mod tests {
             graph.validate();
             let _ = graph.extract_shapes(OverlayRule::Subject, &mut Default::default());
         }
+    }
+
+    #[test]
+    fn test_05() {
+        let subj = vec![
+            vec![
+                [24902.9222201258, 11129.9683052215],
+                [24821.9592401258, 11107.1269052215],
+                [24902.9218201258, 11129.9681852215],
+                [24898.9601001258, 11128.8505052215],
+            ],
+            vec![
+                [20094.9253001258, 12125.6660652215],
+                [20094.9253001258, 12125.6647652215],
+                [29795.5156201258, 10942.5275852215],
+            ],
+            vec![
+                [24902.2200401258, 11129.7702052215],
+                [24902.3098801258, 11129.7955452215],
+                [24902.4788601258, 11129.8432252215],
+            ],
+            vec![
+                [24902.4819801258, 11129.8441052215],
+                [24902.4832001258, 11129.8444452215],
+                [24902.4821401258, 11129.8441452215],
+            ],
+        ];
+        let points = subj.iter().flatten().collect::<Vec<_>>();
+        let adapter =
+            FloatPointAdapter::<_, i64>::with_iter_and_scale_checked(points.into_iter(), 50_000.0).unwrap();
+        let mut options = OverlayOptions::default();
+        options.clean_result = true;
+        options.ogc = true;
+        options.preserve_output_collinear = true;
+        let mut overlay = FloatOverlay::new_custom(adapter, options, Default::default(), 13)
+            .unsafe_add_source(&subj, ShapeType::Subject);
+
+        let _ = overlay.overlay(OverlayRule::Subject, FillRule::NonZero);
     }
 }


### PR DESCRIPTION
### Problem

`extract_ogc` can panic on a self-touching / near-degenerate subject shape when using OGC output.

A minimized standalone reproducer is available here:

https://github.com/Filyus/ioverlay-repro

With `i_overlay = 7.0.0`:

```text
cargo run
# assertion failed: overlay_rule.is_fill_top(link.fill)

cargo run --release
# index out of bounds: the len is 40 but the index is 9223372036854775807
```

The release panic is a downstream symptom. The debug assertion shows the earlier invariant break.

### Root Cause

The first OGC pass classifies contours and skips hole contours for a second pass. In a self-touching sliver case, `skip_contour` can mark a larger traversal as `HoleVisited`. That traversal may include non-hole remnants whose fill does not satisfy:

```rust
overlay_rule.is_fill_top(link.fill)
```

During the second hole pass, the actual hole contour is extracted first. Some non-hole remnants can remain unvisited in the hole-only buffer. The second pass then tries to treat those remnants as hole starts.

In debug this hits:

```rust
debug_assert!(overlay_rule.is_fill_top(link.fill));
```

In release the invalid pseudo-hole can reach `join_sorted_holes`, where parent lookup returns `ContourIndex::EMPTY`; `EMPTY.index()` becomes `usize::MAX >> 1`, producing the `9223372036854775807` panic.

### Fix

When the second OGC pass encounters a `HoleVisited` remnant whose `fill` is not valid for the current `overlay_rule`, consume that contour and continue instead of adding it to `holes` / `anchors`.

This keeps the invariant local to OGC extraction:

```rust
debug_assert!(overlay_rule.is_fill_top(link.fill));
```

Only contours that actually satisfy the hole-start condition are passed to hole binding.

This is intentionally not a `ShapeBinder` fallback: the binder was receiving invalid pseudo-hole input. The fix is applied at the earlier stage where that input is produced.

### Regression Test

Adds a minimized 4-contour / 13-point float regression case derived from the standalone repro. The test uses:

- `OverlayRule::Subject`
- `FillRule::NonZero`
- fixed adapter scale `50000`
- `clean_result = true`
- `ogc = true`
- `preserve_output_collinear = true`

### Verification

```text
cargo test --test crash_tests test_05
cargo test --release --test crash_tests test_05
cargo test --test ocg_tests
cargo test --release --test ocg_tests
cargo test
cargo test --release
```

The standalone repro also passes when patched to this local branch:

```text
OK: produced 17 shape(s) (no panic)
```

### Supersedes

This supersedes #77. That PR handled the downstream `ContourIndex::EMPTY` panic in `ShapeBinder`; this PR fixes the earlier OGC extraction invariant violation that produces the invalid pseudo-hole.

### Note

Prepared with LLM assistance and validated with a minimized standalone reproducer plus debug/release test suites.
